### PR TITLE
fix: mentor endpoint

### DIFF
--- a/api/src/Entity/Duration.php
+++ b/api/src/Entity/Duration.php
@@ -7,6 +7,7 @@ use App\Repository\DurationRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des durées de mentoring possbile (Court terme- Moyen terme - Long terme)
@@ -26,6 +27,7 @@ class Duration
     /**
      * Nom de la durée
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $time;
 

--- a/api/src/Entity/Format.php
+++ b/api/src/Entity/Format.php
@@ -7,6 +7,7 @@ use App\Repository\FormatRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des formats de mentoring possibles (ex : visio - pairprogramming ...)
@@ -26,6 +27,7 @@ class Format
     /**
      * Nom du format
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor"})
      */
     private $name;
 

--- a/api/src/Entity/Mentor.php
+++ b/api/src/Entity/Mentor.php
@@ -7,10 +7,19 @@ use App\Repository\MentorRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des mentors
- * @ApiResource()
+ * @ApiResource(
+ *      normalizationContext={"groups"={"GetAllMentors"}},
+ *      collectionOperations={"get"},
+ * itemOperations={
+ *      "get"={
+ *          "normalization_context"={"groups"={"GetOneMentor"}}
+ *   }
+ *  }
+ * )
  * @ORM\Entity(repositoryClass=MentorRepository::class)
  */
 class Mentor
@@ -24,6 +33,7 @@ class Mentor
     
     /**
      * @ORM\Column(type="datetime")
+     * @Groups({"GetOneMentor"})
      */
     private $createdAt;
 
@@ -35,42 +45,50 @@ class Mentor
     /**
      * Représente : Pourquoi souhaites-tu aider ?
      * @ORM\Column(type="text", nullable=true)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $why_help;
 
     /**
      * Représente : Que signifie, pour toi, être mentor ?
      * @ORM\Column(type="text", nullable=true)
+     * @Groups({"GetOneMentor"})
      */
     private $why_mentor;
 
     /**
      * @ORM\ManyToMany(targetEntity=SoftSkill::class, inversedBy="mentors")
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $soft_skills;
 
     /**
      * @ORM\ManyToMany(targetEntity=StackTech::class, inversedBy="mentors")
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $stack_techs;
 
     /**
      * @ORM\ManyToMany(targetEntity=Duration::class, inversedBy="mentors")
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $durations;
 
     /**
      * @ORM\ManyToMany(targetEntity=Target::class, inversedBy="mentors")
+     * @Groups({"GetOneMentor"})
      */
     private $targets;
 
     /**
      * @ORM\ManyToMany(targetEntity=Format::class, inversedBy="mentors")
+     * @Groups({"GetOneMentor"})
      */
     private $formats;
 
     /**
      * @ORM\OneToOne(targetEntity=User::class, mappedBy="mentor", cascade={"persist", "remove"})
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $userId;
 

--- a/api/src/Entity/SoftSkill.php
+++ b/api/src/Entity/SoftSkill.php
@@ -7,11 +7,14 @@ use App\Repository\SoftSkillRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des compétences générales
  * 
- * @ApiResource()
+ * @ApiResource(
+ *  
+ * )
  * @ORM\Entity(repositoryClass=SoftSkillRepository::class)
  */
 class SoftSkill
@@ -27,6 +30,7 @@ class SoftSkill
      * Nom de la compétence
      * 
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $name;
 

--- a/api/src/Entity/StackTech.php
+++ b/api/src/Entity/StackTech.php
@@ -7,6 +7,7 @@ use App\Repository\StackTechRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des compétences techniques (ex : javascript - php ...)
@@ -26,6 +27,7 @@ class StackTech
     /**
      * Nom de la compétence
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $name;
 

--- a/api/src/Entity/Target.php
+++ b/api/src/Entity/Target.php
@@ -7,6 +7,7 @@ use App\Repository\TargetRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * Liste des cibles possible pour le mentor (ex: junior - reconverti...)
@@ -25,6 +26,7 @@ class Target
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor"})
      */
     private $name;
 

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Repository\UserRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -42,65 +43,76 @@ class User implements UserInterface
     /**
      * Prénom de l'utilisateur
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $first_name;
 
     /**
      * Nom de l'utilisateur
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $last_name;
 
     /**
      * Téléphone de l'utilisateur
      * @ORM\Column(type="integer", nullable=true)
+     * @Groups({"GetOneMentor"})
      */
     private $phone;
 
     /**
      * Lien du profil github de l'utilisateur
      * @ORM\Column(type="string", length=255)
+     * @Groups({"GetOneMentor"})
      */
     private $github;
 
     /**
      * Lien du profil linkedin de l'utilisateur
      * @ORM\Column(type="string", length=255, nullable=true)
+     * @Groups({"GetOneMentor"})
      */
     private $linkedin;
 
     /**
      * Lien du portfolio de l'utilisateur
      * @ORM\Column(type="string", length=512, nullable=true)
+     * @Groups({"GetOneMentor"})
      */
     private $portfolio;
 
     /**
      * Texte biographique de l'utilisateur
      * @ORM\Column(type="text", nullable=true)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $bio;
 
     /**
      * Lien de l'image de l'utilisateur
      * @ORM\Column(type="string", length=512, nullable=true)
+     * @Groups({"GetOneMentor", "GetAllMentors"})
      */
     private $avatar;
 
     /**
      * Texte décrivant le parcours de l'utilisateur
      * @ORM\Column(type="text", nullable=true)
+     * @Groups({"GetOneMentor"})
      */
     private $route;
 
     /**
      * Ouverture au reseaux sociaux (bool)
      * @ORM\Column(type="boolean")
+     * @Groups({"GetOneMentor"})
      */
     private $open_social;
 
     /**
      * @ORM\Column(type="datetime")
+     * @Groups({"GetOneMentor"})
      */
     private $createdAt;
 


### PR DESCRIPTION
Gestion des @groups (terme Symfony) 

sur le endpoint /mentors (liste des mentors) les données de l'user
- "first_name"
-  "last_name"
-  "bio"
-  "avatar"
sont disponible.

Sur le endpoint /mentors/{id} (détails d'un seul mentor)
Toutes les infos de l'user sont disponible.